### PR TITLE
fix deprecated pathContext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1284,6 +1284,11 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",
       "integrity": "sha1-oeUUrfvZLwOiJLpU1pMRHb8fN1Q="
     },
+    "@types/domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA=="
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -5989,13 +5994,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6008,18 +6011,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6122,8 +6122,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6133,7 +6132,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6146,20 +6144,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6176,7 +6171,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6249,8 +6243,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6260,7 +6253,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6366,7 +6358,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6864,10 +6855,11 @@
       }
     },
     "gatsby-custom-md": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gatsby-custom-md/-/gatsby-custom-md-1.0.1.tgz",
-      "integrity": "sha512-59C2tJDqgSTQgtFHmRnLxL7xe6sh8QuGOILMsTPwIG7vcnJ+fnE2Rb7Z823zF9wEZN+aezXBYZKJPz2mqvtkLQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gatsby-custom-md/-/gatsby-custom-md-1.3.0.tgz",
+      "integrity": "sha512-VUOA+mXoX64JoSkbKlodPqJvveJzDFvyx/7MeOKiCzHZDZx1jFLzoBotFE90EMNCXgKEVgis06EH5qMpjx3XBg==",
       "requires": {
+        "html-react-parser": "^0.9.1",
         "react": "^16.8.6",
         "react-dom": "^16.8.6",
         "rehype-react": "^3.1.0"
@@ -7881,10 +7873,31 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
+    "html-dom-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-0.2.3.tgz",
+      "integrity": "sha512-GdzE63/U0IQEvcpAz0cUdYx2zQx0Ai+HWvE9TXEgwP27+SymUzKa7iB4DhjYpf2IdNLfTTOBuMS5nxeWOosSMQ==",
+      "requires": {
+        "@types/domhandler": "2.4.1",
+        "domhandler": "2.4.2",
+        "htmlparser2": "3.10.1"
+      }
+    },
     "html-entities": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
+    "html-react-parser": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-0.9.2.tgz",
+      "integrity": "sha512-EMf70HXgojCC9D1w9EmjdxDVXGqPkwtTa8Bmj1ePDWh7f2CbyEcS4WNDGS+I6ipS0ovUh5Ofe2kkGeW4XuvpaA==",
+      "requires": {
+        "@types/domhandler": "2.4.1",
+        "html-dom-parser": "0.2.3",
+        "react-property": "1.0.1",
+        "style-to-object": "0.2.3"
+      }
     },
     "html-void-elements": {
       "version": "1.0.4",
@@ -12266,6 +12279,11 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-1.0.1.tgz",
+      "integrity": "sha512-1tKOwxFn3dXVomH6pM9IkLkq2Y8oh+fh/lYW3MJ/B03URswUTqttgckOlbxY2XHF3vPG6uanSc4dVsLW/wk3wQ=="
     },
     "react-reconciler": {
       "version": "0.20.4",

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -6,11 +6,7 @@ const Link = props => {
         return <GatsbyLink {...props}>{props.children}</GatsbyLink>;
     }
 
-    return (
-        <a href={props.to}>
-            {props.children}
-        </a>
-    );
+    return <a href={props.to}>{props.children}</a>;
 };
 
 export default Link;

--- a/src/components/navlinks.js
+++ b/src/components/navlinks.js
@@ -48,11 +48,16 @@ class ThemeSwitchButton extends React.Component {
 
         document.body.className = _this.state.darkMode ? "dark-mode" : "";
         if (darkMode) {
-            this.setState({
-                darkMode: (darkMode === "true")
-            }, () => {
-                document.body.className = _this.state.darkMode ? "dark-mode" : "";
-            })
+            this.setState(
+                {
+                    darkMode: darkMode === "true"
+                },
+                () => {
+                    document.body.className = _this.state.darkMode
+                        ? "dark-mode"
+                        : "";
+                }
+            );
         }
 
         this.switchBtn.addEventListener("click", function() {
@@ -60,7 +65,7 @@ class ThemeSwitchButton extends React.Component {
                 darkMode: !_this.state.darkMode
             });
             localStorage.setItem("darkMode", _this.state.darkMode);
-            
+
             document.body.className = _this.state.darkMode ? "dark-mode" : "";
         });
     }
@@ -68,7 +73,10 @@ class ThemeSwitchButton extends React.Component {
         return (
             <React.Fragment>
                 <li className="switch-theme">
-                    <div className="switch-button" ref={c => (this.switchBtn = c)}>
+                    <div
+                        className="switch-button"
+                        ref={c => (this.switchBtn = c)}
+                    >
                         <div
                             title="Switch to Dark Mode"
                             data-switch-to="dark"

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -3,14 +3,13 @@ import { Link } from "gatsby";
 import { ChevronLeft, ChevronRight } from "./icons";
 import "../style/pagination.less";
 
-export default function({ pathContext, type }) {
-
-    if (pathContext.numPages > 1) {
+export default function({ pageContext, type }) {
+    if (pageContext.numPages > 1) {
         let listItems = [];
-        for (let i = 1; i <= pathContext.numPages; i++) {
+        for (let i = 1; i <= pageContext.numPages; i++) {
             listItems.push(
                 <li
-                    className={i === pathContext.currentPage ? "active" : ""}
+                    className={i === pageContext.currentPage ? "active" : ""}
                     key={"PaginationItem" + i}
                 >
                     <Link
@@ -31,16 +30,16 @@ export default function({ pathContext, type }) {
         return (
             <div className="pagination">
                 <ul>
-                    {pathContext.currentPage !== 1 && (
+                    {pageContext.currentPage !== 1 && (
                         <li>
                             <Link
                                 to={
                                     "/" +
                                     type +
                                     "/" +
-                                    (pathContext.currentPage - 1 === 1
+                                    (pageContext.currentPage - 1 === 1
                                         ? ""
-                                        : pathContext.currentPage - 1)
+                                        : pageContext.currentPage - 1)
                                 }
                                 title="Previous Page"
                             >
@@ -51,14 +50,14 @@ export default function({ pathContext, type }) {
                         </li>
                     )}
                     {listItems}
-                    {pathContext.currentPage !== pathContext.numPages && (
+                    {pageContext.currentPage !== pageContext.numPages && (
                         <li>
                             <Link
                                 to={
                                     "/" +
                                     type +
                                     "/" +
-                                    (pathContext.currentPage + 1)
+                                    (pageContext.currentPage + 1)
                                 }
                                 title="Next Page"
                             >

--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -17,7 +17,7 @@ class BlogList extends React.Component {
                     </div>
                     <BlogItems data={query} />
                     <Pagination
-                        pathContext={this.props.pathContext}
+                        pageContext={this.props.pageContext}
                         type="blog"
                     />
                 </section>
@@ -28,11 +28,11 @@ class BlogList extends React.Component {
     }
 }
 
-export default function({ data, pathContext }) {
+export default function({ data, pageContext }) {
     return (
         <Layout>
             <SEO lang="en" title="Blog" />
-            <BlogList datas={data} pathContext={pathContext} />
+            <BlogList datas={data} pageContext={pageContext} />
         </Layout>
     );
 }

--- a/src/templates/portfolio-list.js
+++ b/src/templates/portfolio-list.js
@@ -17,7 +17,7 @@ class PortfolioList extends React.Component {
                     </div>
                     <PortfolioItems data={query} />
                     <Pagination
-                        pathContext={this.props.pathContext}
+                        pageContext={this.props.pageContext}
                         type="portfolio"
                     />
                 </section>
@@ -28,11 +28,11 @@ class PortfolioList extends React.Component {
     }
 }
 
-export default function({ data, pathContext }) {
+export default function({ data, pageContext }) {
     return (
         <Layout>
             <SEO lang="en" title="Portfolio" />
-            <PortfolioList datas={data} pathContext={pathContext} />
+            <PortfolioList datas={data} pageContext={pageContext} />
         </Layout>
     );
 }


### PR DESCRIPTION
Close #12 

In gatsby V2, pathContext is renamed into pageContext. more information [here](https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-pathcontext-to-pagecontext)

btw, do i have to increment version? i don't know how 😅 